### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,5 +27,5 @@ inputs:
     default: 'latest'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Got the following notice:

Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: mukeshsolanki/bundletool-action@v1.0.1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.